### PR TITLE
[codex] Add skill detail sidebar navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -43,6 +43,7 @@
 
   --page-gutter: var(--space-4);
   --page-max: 1200px;
+  --skill-sidebar-width: 280px;
 }
 
 * {
@@ -424,6 +425,121 @@ main {
   padding: var(--space-12) 0 var(--space-16);
 }
 
+.skill-page {
+  width: 100%;
+  max-width: none;
+}
+
+.skill-detail-shell {
+  display: grid;
+  gap: var(--space-8);
+}
+
+.skill-detail-main {
+  min-width: 0;
+}
+
+.skill-sidebar {
+  border-right: 1px solid var(--color-border);
+  background: rgba(247, 247, 245, 0.94);
+  color: var(--color-text-secondary);
+  display: none;
+}
+
+.skill-sidebar-inner {
+  display: grid;
+  align-content: start;
+  gap: var(--space-5, 20px);
+  min-height: 100%;
+  padding: var(--space-6) var(--space-4) var(--space-8);
+}
+
+.sidebar-home-link {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-tight);
+  padding: 8px 10px;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.sidebar-home-link:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.sidebar-home-link span {
+  color: var(--color-text-muted);
+}
+
+.sidebar-block {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.sidebar-block h2 {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  letter-spacing: 0;
+  line-height: var(--leading-tight);
+  text-transform: uppercase;
+}
+
+.sidebar-list {
+  display: grid;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.sidebar-toc-link,
+.sidebar-skill-link {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  border-radius: 5px;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
+  overflow-wrap: anywhere;
+  padding: 6px 10px;
+  transition:
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.sidebar-toc-link[data-level="3"] {
+  border-left: 1px solid var(--color-border);
+  border-radius: 0 5px 5px 0;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  margin-left: var(--space-2);
+  padding-left: var(--space-3);
+}
+
+.sidebar-toc-link:hover,
+.sidebar-skill-link:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.sidebar-skill-link small {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-tight);
+}
+
 .breadcrumb {
   display: flex;
   flex-wrap: wrap;
@@ -524,6 +640,12 @@ main {
   font-size: var(--text-lg);
   font-weight: var(--font-semibold);
   line-height: var(--leading-tight);
+}
+
+.article-body section[id],
+.article-body h2,
+.article-body h3 {
+  scroll-margin-top: 96px;
 }
 
 .article-body p,
@@ -801,10 +923,43 @@ main {
   }
 }
 
+@media (min-width: 800px) {
+  .skill-sidebar {
+    display: block;
+    position: fixed;
+    top: 64px;
+    bottom: 0;
+    left: 0;
+    z-index: 4;
+    width: min(var(--skill-sidebar-width), 32vw);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .skill-sidebar-inner {
+    padding-top: var(--space-6);
+  }
+
+  .skill-detail-main {
+    margin-left: min(var(--skill-sidebar-width), 32vw);
+    padding-inline: var(--space-8);
+  }
+}
+
 @media (min-width: 1024px) {
   .skill-grid,
   .loading-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .skill-detail-main {
+    padding-inline: var(--space-12);
+  }
+}
+
+@media (min-width: 1440px) {
+  :root {
+    --skill-sidebar-width: 300px;
   }
 }
 

--- a/app/skill/[slug]/page.tsx
+++ b/app/skill/[slug]/page.tsx
@@ -2,11 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { NotionContent } from "@/components/NotionContent";
+import { SkillSidebar } from "@/components/SkillSidebar";
 import {
   getAdjacentSkills,
   getPublishedSkills,
   getSkillBySlug
 } from "@/lib/notion";
+import { getRelatedSkills, getSkillSections } from "@/lib/skill-navigation";
 
 export const revalidate = 3600;
 
@@ -51,61 +53,72 @@ export default async function SkillPage({ params }: PageProps) {
     notFound();
   }
 
-  const adjacent = await getAdjacentSkills(skill.slug);
+  const [adjacent, skills] = await Promise.all([
+    getAdjacentSkills(skill.slug),
+    getPublishedSkills()
+  ]);
+  const sections = getSkillSections(skill);
+  const relatedSkills = getRelatedSkills(skill, skills);
 
   return (
-    <main>
-      <article className="article-layout">
-        <nav className="breadcrumb" aria-label="面包屑">
-          <Link href="/">首页</Link>
-          {skill.category ? <span>{skill.category}</span> : null}
-          <span>{skill.name}</span>
-        </nav>
+    <main className="skill-page">
+      <div className="skill-detail-shell">
+        <SkillSidebar sections={sections} relatedSkills={relatedSkills} />
 
-        <header className="article-header">
-          {skill.category ? (
-            <span className="category-pill">{skill.category}</span>
-          ) : null}
-          <h1>{skill.name}</h1>
-          <p>{skill.summary || "暂无简介"}</p>
-          <div className="article-actions" aria-label="外部链接">
-            {skill.githubUrl ? (
-              <a href={skill.githubUrl} target="_blank" rel="noreferrer">
-                在 GitHub 查看
-              </a>
-            ) : null}
-            {skill.xhsUrl ? (
-              <a href={skill.xhsUrl} target="_blank" rel="noreferrer">
-                查看小红书原帖
-              </a>
-            ) : null}
-          </div>
-        </header>
+        <div className="skill-detail-main">
+          <article className="article-layout">
+            <nav className="breadcrumb" aria-label="面包屑">
+              <Link href="/">首页</Link>
+              {skill.category ? <span>{skill.category}</span> : null}
+              <span>{skill.name}</span>
+            </nav>
 
-        <NotionContent
-          blocks={skill.content}
-          fallbackSections={skill.demoSections}
-        />
-      </article>
+            <header className="article-header">
+              {skill.category ? (
+                <span className="category-pill">{skill.category}</span>
+              ) : null}
+              <h1>{skill.name}</h1>
+              <p>{skill.summary || "暂无简介"}</p>
+              <div className="article-actions" aria-label="外部链接">
+                {skill.githubUrl ? (
+                  <a href={skill.githubUrl} target="_blank" rel="noreferrer">
+                    在 GitHub 查看
+                  </a>
+                ) : null}
+                {skill.xhsUrl ? (
+                  <a href={skill.xhsUrl} target="_blank" rel="noreferrer">
+                    查看小红书原帖
+                  </a>
+                ) : null}
+              </div>
+            </header>
 
-      <nav className="pagination" aria-label="上一篇和下一篇">
-        {adjacent.previous ? (
-          <Link href={`/skill/${adjacent.previous.slug}`}>
-            <span>上一篇</span>
-            {adjacent.previous.name}
-          </Link>
-        ) : (
-          <span />
-        )}
-        {adjacent.next ? (
-          <Link href={`/skill/${adjacent.next.slug}`}>
-            <span>下一篇</span>
-            {adjacent.next.name}
-          </Link>
-        ) : (
-          <span />
-        )}
-      </nav>
+            <NotionContent
+              blocks={skill.content}
+              fallbackSections={skill.demoSections}
+            />
+          </article>
+
+          <nav className="pagination" aria-label="上一篇和下一篇">
+            {adjacent.previous ? (
+              <Link href={`/skill/${adjacent.previous.slug}`}>
+                <span>上一篇</span>
+                {adjacent.previous.name}
+              </Link>
+            ) : (
+              <span />
+            )}
+            {adjacent.next ? (
+              <Link href={`/skill/${adjacent.next.slug}`}>
+                <span>下一篇</span>
+                {adjacent.next.name}
+              </Link>
+            ) : (
+              <span />
+            )}
+          </nav>
+        </div>
+      </div>
     </main>
   );
 }

--- a/components/NotionContent.tsx
+++ b/components/NotionContent.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import type { RichTextItemResponse } from "@notionhq/client/build/src/api-endpoints";
 import type { ReactNode } from "react";
+import {
+  sectionIdFromBlock,
+  sectionIdFromIndex
+} from "@/lib/skill-navigation";
 import type { NotionBlock, SkillContentSection } from "@/types";
 
 function plainText(items: RichTextItemResponse[]) {
@@ -94,19 +98,19 @@ function renderBlock(block: NotionBlock) {
       );
     case "heading_1":
       return (
-        <h2 key={block.id}>
+        <h2 id={sectionIdFromBlock(block)} key={block.id}>
           <RichText items={block.heading_1.rich_text} />
         </h2>
       );
     case "heading_2":
       return (
-        <h2 key={block.id}>
+        <h2 id={sectionIdFromBlock(block)} key={block.id}>
           <RichText items={block.heading_2.rich_text} />
         </h2>
       );
     case "heading_3":
       return (
-        <h3 key={block.id}>
+        <h3 id={sectionIdFromBlock(block)} key={block.id}>
           <RichText items={block.heading_3.rich_text} />
         </h3>
       );
@@ -237,8 +241,11 @@ export function NotionContent({
 
   return (
     <div className="article-body">
-      {(fallbackSections ?? []).map((section) => (
-        <section key={section.title}>
+      {(fallbackSections ?? []).map((section, index) => (
+        <section
+          id={sectionIdFromIndex(index)}
+          key={`${section.title}-${index}`}
+        >
           <h2>{section.title}</h2>
           {section.body.map((paragraph) => (
             <p key={paragraph}>{paragraph}</p>

--- a/components/SkillSidebar.tsx
+++ b/components/SkillSidebar.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import type { Skill } from "@/types";
+import type { SkillSectionNavItem } from "@/lib/skill-navigation";
+
+type SkillSidebarProps = {
+  sections: SkillSectionNavItem[];
+  relatedSkills: Array<Pick<Skill, "category" | "name" | "slug">>;
+};
+
+export function SkillSidebar({
+  sections,
+  relatedSkills
+}: SkillSidebarProps) {
+  return (
+    <aside className="skill-sidebar" aria-label="Skill 页面导航">
+      <div className="skill-sidebar-inner">
+        <Link className="sidebar-home-link" href="/">
+          <span aria-hidden="true">←</span>
+          全部 Skills
+        </Link>
+
+        {sections.length > 0 ? (
+          <section className="sidebar-block" aria-labelledby="page-toc-title">
+            <h2 id="page-toc-title">本页目录</h2>
+            <ol className="sidebar-list">
+              {sections.map((section) => (
+                <li key={section.id}>
+                  <a
+                    className="sidebar-toc-link"
+                    data-level={section.level}
+                    href={`#${section.id}`}
+                  >
+                    {section.title}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </section>
+        ) : null}
+
+        {relatedSkills.length > 0 ? (
+          <section
+            className="sidebar-block"
+            aria-labelledby="related-skills-title"
+          >
+            <h2 id="related-skills-title">相关 Skill</h2>
+            <ul className="sidebar-list">
+              {relatedSkills.map((skill) => (
+                <li key={skill.slug}>
+                  <Link
+                    className="sidebar-skill-link"
+                    href={`/skill/${skill.slug}`}
+                  >
+                    <span>{skill.name}</span>
+                    {skill.category ? <small>{skill.category}</small> : null}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/lib/skill-navigation.ts
+++ b/lib/skill-navigation.ts
@@ -1,0 +1,103 @@
+import type { NotionBlock, Skill, SkillContentSection } from "@/types";
+
+export type SkillSectionNavItem = {
+  id: string;
+  title: string;
+  level: 2 | 3;
+};
+
+export function sectionIdFromBlock(block: Pick<NotionBlock, "id">) {
+  return `section-${block.id}`;
+}
+
+export function sectionIdFromIndex(index: number) {
+  return `section-${index + 1}`;
+}
+
+function richTextPlainText(items: Array<{ plain_text: string }>) {
+  return items.map((item) => item.plain_text).join("").trim();
+}
+
+function headingText(block: NotionBlock) {
+  switch (block.type) {
+    case "heading_1":
+      return richTextPlainText(block.heading_1.rich_text);
+    case "heading_2":
+      return richTextPlainText(block.heading_2.rich_text);
+    case "heading_3":
+      return richTextPlainText(block.heading_3.rich_text);
+    default:
+      return "";
+  }
+}
+
+function headingLevel(block: NotionBlock): SkillSectionNavItem["level"] {
+  return block.type === "heading_3" ? 3 : 2;
+}
+
+function collectNotionSections(blocks: NotionBlock[]) {
+  const sections: SkillSectionNavItem[] = [];
+
+  for (const block of blocks) {
+    if (
+      block.type === "heading_1" ||
+      block.type === "heading_2" ||
+      block.type === "heading_3"
+    ) {
+      const title = headingText(block);
+
+      if (title) {
+        sections.push({
+          id: sectionIdFromBlock(block),
+          title,
+          level: headingLevel(block)
+        });
+      }
+    }
+
+    if (block.children?.length) {
+      sections.push(...collectNotionSections(block.children));
+    }
+  }
+
+  return sections;
+}
+
+function collectFallbackSections(sections: SkillContentSection[] = []) {
+  return sections
+    .map((section, index) => ({
+      id: sectionIdFromIndex(index),
+      title: section.title.trim(),
+      level: 2 as const
+    }))
+    .filter((section) => section.title.length > 0);
+}
+
+export function getSkillSections(skill: Skill) {
+  if (Array.isArray(skill.content)) {
+    return collectNotionSections(skill.content);
+  }
+
+  return collectFallbackSections(skill.demoSections);
+}
+
+export function getRelatedSkills(
+  currentSkill: Skill,
+  skills: Skill[],
+  limit = 5
+) {
+  const sameCategory = currentSkill.category
+    ? skills.filter(
+        (skill) =>
+          skill.slug !== currentSkill.slug &&
+          skill.category === currentSkill.category
+      )
+    : [];
+  const categorySlugs = new Set(sameCategory.map((skill) => skill.slug));
+  const fallbackSkills = skills.filter(
+    (skill) =>
+      skill.slug !== currentSkill.slug && !categorySlugs.has(skill.slug)
+  );
+
+  return [...sameCategory, ...fallbackSkills].slice(0, limit);
+}


### PR DESCRIPTION
## Summary
- Add a reusable skill detail sidebar with page section anchors and related skill links.
- Generate stable navigation items from Notion headings and fallback demo sections.
- Update the detail page layout to use a fixed left documentation-style navigation pane on desktop.

## Validation
- npm run typecheck
- npm run build

Closes #1