### PR TITLE
Fix mobile skill page horizontal padding

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -437,6 +437,7 @@ main {
 
 .skill-detail-main {
   min-width: 0;
+  padding-inline: var(--page-gutter);
 }
 
 .skill-sidebar {


### PR DESCRIPTION
## Summary
- Add `padding-inline: var(--page-gutter)` to `.skill-detail-main` base style, fixing content that sits flush against screen edges on mobile devices (< 800px)

## Root cause
`.skill-page` overrides `main`'s width constraint with `width: 100%; max-width: none` (needed for desktop sidebar layout), but `.skill-detail-main` had no compensating horizontal padding on mobile. Desktop breakpoints (800px+, 1024px+) already set `padding-inline`, so only mobile was affected.

## Test plan
- [ ] Open any skill page on mobile viewport (375px)
- [ ] Confirm content has ~16px left/right padding
- [ ] Confirm desktop layout (800px+) sidebar + padding is unchanged

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)