### PR TITLE
[codex] Make skill breadcrumbs sticky

### DIFF
--- a/app/category/[name]/page.tsx
+++ b/app/category/[name]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { DocsSidebar } from "@/components/DocsSidebar";
 import { SkillCard } from "@/components/SkillCard";
@@ -38,11 +37,6 @@ export default async function CategoryPage({ params }: PageProps) {
 
         <div className="docs-content">
           <article className="article-layout">
-            <nav className="breadcrumb" aria-label="面包屑">
-              <Link href="/">首页</Link>
-              <span>{categoryName}</span>
-            </nav>
-
             <header className="article-header">
               <h1>{categoryName}</h1>
               <p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -44,6 +44,8 @@
   --page-gutter: var(--space-4);
   --page-max: 1200px;
   --skill-sidebar-width: 280px;
+  --site-header-height: 64px;
+  --breadcrumb-bar-height: 58px;
 }
 
 html.dark {
@@ -766,31 +768,6 @@ main {
   line-height: var(--leading-tight);
 }
 
-.breadcrumb {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  align-items: center;
-  margin-bottom: var(--space-12);
-  color: var(--color-text-muted);
-  font-size: var(--text-sm);
-}
-
-.breadcrumb a {
-  color: var(--color-text-secondary);
-}
-
-.breadcrumb a:hover {
-  color: var(--color-accent);
-}
-
-.breadcrumb a::before,
-.breadcrumb span::before {
-  content: "/";
-  margin-right: var(--space-2);
-  color: var(--color-border-strong);
-}
-
 .article-header {
   display: grid;
   gap: var(--space-4);
@@ -873,6 +850,14 @@ main {
 .article-body h2,
 .article-body h3 {
   scroll-margin-top: 96px;
+}
+
+.skill-page .article-body section[id],
+.skill-page .article-body h2,
+.skill-page .article-body h3 {
+  scroll-margin-top: calc(
+    var(--site-header-height) + var(--breadcrumb-bar-height) + var(--space-6)
+  );
 }
 
 .article-body p,
@@ -1217,7 +1202,7 @@ main {
   .skill-sidebar {
     display: block;
     position: fixed;
-    top: 64px;
+    top: var(--site-header-height);
     bottom: 0;
     right: 0;
     z-index: 4;
@@ -1233,6 +1218,10 @@ main {
   .skill-detail-main {
     margin-right: min(var(--skill-sidebar-width), 32vw);
     padding-inline: var(--space-8);
+  }
+
+  .skill-page .skill-sidebar {
+    top: calc(var(--site-header-height) + var(--breadcrumb-bar-height));
   }
 }
 
@@ -1274,9 +1263,71 @@ main {
   text-align: left;
 }
 
+.docs-breadcrumb-bar {
+  position: sticky;
+  top: var(--site-header-height);
+  z-index: 9;
+  min-height: var(--breadcrumb-bar-height);
+  backdrop-filter: blur(18px);
+}
+
 .docs-mobile-sidebar-trigger svg {
   flex: 0 0 auto;
   color: var(--color-text-muted);
+}
+
+.docs-sidebar-menu-button {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-muted);
+  transition:
+    background 100ms ease,
+    color 100ms ease;
+}
+
+.docs-sidebar-menu-button:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.docs-breadcrumb {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+  line-height: var(--leading-tight);
+}
+
+.docs-breadcrumb-item {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.docs-breadcrumb a:hover {
+  color: var(--color-accent);
+}
+
+.docs-breadcrumb-current {
+  flex: 1 1 auto;
+  color: var(--color-text-primary);
+  font-weight: var(--font-semibold);
+}
+
+.docs-breadcrumb-separator {
+  flex: 0 0 auto;
+  color: var(--color-border-strong);
 }
 
 .docs-sidebar-backdrop {
@@ -1489,8 +1540,16 @@ main {
     display: none;
   }
 
+  .docs-mobile-sidebar-trigger.docs-breadcrumb-bar {
+    display: flex;
+  }
+
+  .docs-breadcrumb-bar .docs-sidebar-menu-button {
+    display: none;
+  }
+
   .docs-sidebar {
-    top: 64px;
+    top: var(--site-header-height);
     z-index: 4;
     width: min(var(--skill-sidebar-width), 32vw);
     background: rgba(250, 250, 248, 0.96);
@@ -1515,6 +1574,10 @@ main {
   .docs-content {
     margin-left: min(var(--skill-sidebar-width), 32vw);
     padding-inline: var(--space-8);
+  }
+
+  .skill-page .docs-sidebar {
+    top: calc(var(--site-header-height) + var(--breadcrumb-bar-height));
   }
 }
 
@@ -1598,6 +1661,10 @@ main {
 }
 
 @media (max-width: 640px) {
+  :root {
+    --site-header-height: 58px;
+  }
+
   .site-nav {
     min-height: 58px;
   }

--- a/app/skill/[slug]/page.tsx
+++ b/app/skill/[slug]/page.tsx
@@ -60,11 +60,20 @@ export default async function SkillPage({ params }: PageProps) {
   }
 
   const sections = getSkillSections(skill);
+  const breadcrumbItems = [
+    skill.category
+      ? {
+          label: skill.category,
+          href: `/category/${encodeURIComponent(skill.category)}`
+        }
+      : { label: "Skills 概览", href: "/" },
+    { label: skill.name }
+  ];
 
   return (
-    <main className="docs-page">
+    <main className="docs-page skill-page">
       <div className="docs-layout">
-        <DocsSidebar config={sidebarConfig} />
+        <DocsSidebar config={sidebarConfig} breadcrumbItems={breadcrumbItems} />
 
         <div className="docs-content">
           <div className="skill-detail-shell">
@@ -72,16 +81,6 @@ export default async function SkillPage({ params }: PageProps) {
 
             <div className="skill-detail-main">
               <article className="article-layout">
-                <nav className="breadcrumb" aria-label="面包屑">
-                  <Link href="/">首页</Link>
-                  {skill.category ? (
-                    <Link href={`/#category=${encodeURIComponent(skill.category)}`}>
-                      {skill.category}
-                    </Link>
-                  ) : null}
-                  <span>{skill.name}</span>
-                </nav>
-
                 <header className="article-header">
                   {skill.category ? (
                     <span className="category-pill">{skill.category}</span>

--- a/components/DocsSidebar.tsx
+++ b/components/DocsSidebar.tsx
@@ -3,11 +3,17 @@
 import { Menu, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import type { SidebarConfig } from "@/lib/sidebar-config";
+
+export type DocsBreadcrumbItem = {
+  label: string;
+  href?: string;
+};
 
 type DocsSidebarProps = {
   config: SidebarConfig;
+  breadcrumbItems?: DocsBreadcrumbItem[];
 };
 
 function groupItemsId(href: string) {
@@ -16,11 +22,12 @@ function groupItemsId(href: string) {
     .replace(/[^a-zA-Z0-9_-]+/g, "-")}`;
 }
 
-export function DocsSidebar({ config }: DocsSidebarProps) {
+export function DocsSidebar({ config, breadcrumbItems }: DocsSidebarProps) {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const sidebarId = "docs-sidebar-navigation";
+  const hasBreadcrumb = Boolean(breadcrumbItems?.length);
 
   const currentTitle = useMemo(() => {
     const directLink = config.links.find((link) => link.href === pathname);
@@ -92,16 +99,55 @@ export function DocsSidebar({ config }: DocsSidebarProps) {
 
   return (
     <>
-      <button
-        type="button"
-        className="docs-mobile-sidebar-trigger"
-        aria-controls={sidebarId}
-        aria-expanded={isSidebarOpen}
-        onClick={() => setIsSidebarOpen(true)}
-      >
-        <Menu size={22} aria-hidden="true" />
-        <span>{currentTitle}</span>
-      </button>
+      {hasBreadcrumb ? (
+        <div className="docs-mobile-sidebar-trigger docs-breadcrumb-bar">
+          <button
+            type="button"
+            className="docs-sidebar-menu-button"
+            aria-controls={sidebarId}
+            aria-expanded={isSidebarOpen}
+            aria-label="打开导航目录"
+            onClick={() => setIsSidebarOpen(true)}
+          >
+            <Menu size={22} aria-hidden="true" />
+          </button>
+
+          <nav className="docs-breadcrumb" aria-label="面包屑">
+            {breadcrumbItems?.map((item, index) => (
+              <Fragment key={`${item.href ?? "current"}-${item.label}`}>
+                {index > 0 ? (
+                  <span className="docs-breadcrumb-separator" aria-hidden="true">
+                    &rsaquo;
+                  </span>
+                ) : null}
+                {item.href ? (
+                  <Link className="docs-breadcrumb-item" href={item.href}>
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    className="docs-breadcrumb-item docs-breadcrumb-current"
+                    aria-current="page"
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </Fragment>
+            ))}
+          </nav>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="docs-mobile-sidebar-trigger"
+          aria-controls={sidebarId}
+          aria-expanded={isSidebarOpen}
+          onClick={() => setIsSidebarOpen(true)}
+        >
+          <Menu size={22} aria-hidden="true" />
+          <span>{currentTitle}</span>
+        </button>
+      )}
 
       <button
         type="button"


### PR DESCRIPTION
## Summary

- Make the skill detail breadcrumb live in a sticky bar below the site header.
- Add a compact mobile structure with a navigation menu button plus category/current skill trail.
- Remove the old inline breadcrumb from category pages so `/首页/分类名` no longer appears there.
- Adjust sidebar offsets and heading scroll margins so sticky navigation does not cover content.

Closes #10

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
