### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1611,6 +1611,48 @@ html.dark .cta-section::before {
   font-family: var(--font-mono);
 }
 
+.code-block-wrapper {
+  position: relative;
+}
+
+.code-block-wrapper pre {
+  margin: var(--space-4) 0 0;
+  padding: var(--space-4);
+}
+
+.copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: var(--color-border);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.code-block-wrapper:hover .copy-button,
+.copy-button:focus {
+  opacity: 1;
+}
+
+.copy-button:hover {
+  background: var(--color-text-secondary);
+  color: var(--color-bg);
+}
+
+.copy-button:focus {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
+}
+
 .rt-bold {
   font-weight: var(--font-semibold);
 }

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+export function CodeBlock({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="code-block-wrapper">
+      <button
+        aria-label="Copy code"
+        className="copy-button"
+        onClick={handleCopy}
+        type="button"
+      >
+        {copied ? <Check size={16} /> : <Copy size={16} />}
+      </button>
+      <pre>
+        <code>{text}</code>
+      </pre>
+    </div>
+  );
+}

--- a/components/NotionContent.tsx
+++ b/components/NotionContent.tsx
@@ -6,6 +6,7 @@ import {
   sectionIdFromIndex
 } from "@/lib/skill-navigation";
 import type { NotionBlock, SkillContentSection } from "@/types";
+import { CodeBlock } from "@/components/CodeBlock";
 
 function plainText(items: RichTextItemResponse[]) {
   return items.map((item) => item.plain_text).join("");
@@ -222,9 +223,7 @@ function renderBlock(block: NotionBlock) {
       );
     case "code":
       return (
-        <pre key={block.id}>
-          <code>{plainText(block.code.rich_text)}</code>
-        </pre>
+        <CodeBlock key={block.id} text={plainText(block.code.rich_text)} />
       );
     case "divider":
       return <hr key={block.id} />;
@@ -348,7 +347,7 @@ export function NotionContent({
           {section.body.map((paragraph) => (
             <p key={paragraph}>{paragraph}</p>
           ))}
-          {section.code ? <pre><code>{section.code}</code></pre> : null}
+          {section.code ? <CodeBlock text={section.code} /> : null}
         </section>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Add `CodeBlock` client component with one-click copy button (Copy → Check icon, 2s confirmation)
- Replace plain `<pre><code>` in `NotionContent.tsx` with `CodeBlock` for both Notion and demo fallback code blocks
- Add `.code-block-wrapper` and `.copy-button` CSS — button hidden by default, appears on hover

Fixes #14

## Test plan
- [ ] Open a skill detail page with code blocks
- [ ] Hover over code block — copy button appears in top-right corner
- [ ] Click copy button — icon changes to check, paste content to verify correctness
- [ ] Verify dark mode styling
- [ ] Verify mobile tap works