### PR TITLE
fix: optimize Notion table column widths

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1718,7 +1718,7 @@ html.dark .cta-section::before {
 
 .notion-table {
   width: 100%;
-  min-width: 560px;
+  table-layout: fixed;
   border-collapse: collapse;
   font-size: var(--text-sm);
   line-height: var(--leading-normal);
@@ -1726,12 +1726,19 @@ html.dark .cta-section::before {
 
 .notion-table th,
 .notion-table td {
-  min-width: 132px;
   border-right: 1px solid var(--color-border);
   border-bottom: 1px solid var(--color-border);
   padding: var(--space-3);
   text-align: left;
   vertical-align: top;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.notion-table th:first-child,
+.notion-table td:first-child {
+  width: 120px;
 }
 
 .notion-table th {


### PR DESCRIPTION
## Summary
- Switch .notion-table to table-layout: fixed for predictable column widths
- Set first column to fixed 120px, remaining columns share remaining space equally
- Add text wrapping properties for proper word-break in table cells
- Remove excessive min-width values that caused tables to overflow

Closes #19

## Test plan
- [ ] Verify Notion child_database tables render with compact first column
- [ ] Verify long text wraps correctly within table cells
- [ ] Verify horizontal scroll still works on mobile
- [ ] Verify dark mode table styling is unaffected